### PR TITLE
update: Fixed urlparse for Python 3

### DIFF
--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -5,7 +5,12 @@ import re
 import requests
 
 from bs4 import BeautifulSoup
-import urlparse
+try:
+    # Python 2 has a standard urlparse library
+    from urlparse import urlparse, ParseResult
+except:
+    # Python 3 has the same library hidden in urllib.parse
+    from urllib.parse import urlparse, ParseResult
 
 
 MAX_FILEIZE =  2**19  # bytes; this is .5MB
@@ -80,7 +85,7 @@ def is_parsed_valid_url(parsed, require_public_netloc=True, http_only=True):
             defaults True
             requires http or https for the scheme
     """
-    assert isinstance(parsed, urlparse.ParseResult)
+    assert isinstance(parsed, ParseResult)
     log.debug("is_parsed_valid_url = %s", parsed)
     if not all((parsed.scheme, parsed.netloc)):
         log.debug(" FALSE - missing `scheme` or `netloc`")
@@ -149,7 +154,7 @@ def is_parsed_valid_url(parsed, require_public_netloc=True, http_only=True):
 
 def is_parsed_valid_relative(parsed):
     """returns bool"""
-    assert isinstance(parsed, urlparse.ParseResult)
+    assert isinstance(parsed, ParseResult)
     if parsed.path and not any((parsed.scheme, parsed.hostname)):
         return True
     return False
@@ -157,7 +162,7 @@ def is_parsed_valid_relative(parsed):
 
 def parsed_to_relative(parsed):
     """turns a parsed url into a full relative url"""
-    assert isinstance(parsed, urlparse.ParseResult)
+    assert isinstance(parsed, ParseResult)
     _path = parsed.path
     # cleanup, might be unnecessary now
     if _path and _path[0] != "/":
@@ -172,12 +177,12 @@ def parsed_to_relative(parsed):
 
 def is_url_valid(url, require_public_netloc=None):
     """
-    tries to parse a url. if valid returns `urlparse.ParseResult`
+    tries to parse a url. if valid returns `ParseResult`
     (boolean eval is True); if invalid returns `False`
     """
     if url is None:
         return False
-    parsed = urlparse.urlparse(url)
+    parsed = urlparse(url)
     if is_parsed_valid_url(parsed, require_public_netloc=require_public_netloc):
         return parsed
     return False
@@ -206,7 +211,7 @@ def url_to_absolute_url(url_test, url_fallback=None, require_public_netloc=None)
     if url_test is None and url_fallback is not None:
         return url_fallback
 
-    parsed = urlparse.urlparse(url_test)
+    parsed = urlparse(url_test)
 
     _path = parsed.path
     if _path:
@@ -240,7 +245,7 @@ def url_to_absolute_url(url_test, url_fallback=None, require_public_netloc=None)
         # ok, the URL isn't valid
         # can we re-assemble it
         if url_fallback:
-            parsed_fallback = urlparse.urlparse(url_fallback)
+            parsed_fallback = urlparse(url_fallback)
             if is_parsed_valid_url(
                 parsed_fallback,
                 require_public_netloc=require_public_netloc
@@ -433,7 +438,7 @@ class MetadataParser(object):
         """
         # should we even download/parse this?
         if not force_parse and self.only_parse_file_extensions is not None:
-            parsed = urlparse.urlparse(self.url)
+            parsed = urlparse(self.url)
             path = parsed.path
             if path:
                 url_fpath = path.split('.')


### PR DESCRIPTION
* Extended the MindMapMarker's simple fix from
  (https://github.com/jvanasco/metadata_parser/issues/5) to make sure
  metadata_parser works with Python 3 too.

Signed-off-by: mr.Shu <mr@shu.io>

--------------------------------

Note that this fixes #5.