### PR TITLE
handle malformed content and legacy twitter

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,12 @@
 1.0
     1.0 will be a complete api overhaul
 
+0.9.20
+	* support for deprecated `twitter:label` and `twitter:data` metatags, which use "value" instead of "content".
+	* new param to `__init__` and `parse`: `support_malformed` (default `None`).
+	  if true, will support malformed parsing (such as consulting "value" instead of "content".
+	  functionality extended from PR #13 (https://github.com/jvanasco/metadata_parser/pull/13) from https://github.com/amensouissi
+
 0.9.19
 	* addressing https://github.com/jvanasco/metadata_parser/issues/12
 		on pages with duplicate metadata keys, additional elements are ignored

--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -1499,9 +1499,11 @@ class MetadataParser(object):
                                           )
         for twitter in twitters:
             try:
+                # for a twitter:label/data meta tags, we must use a 'value' attr
+                raw_value = twitter.get('content', twitter.get('value', None))
                 parsed_result._add_discovered(_target_container='twitter',
                                               _target_key=twitter['name'][8:],
-                                              _raw_value=twitter['content'],
+                                              _raw_value=raw_value,
                                               )
             except (AttributeError, KeyError):
                 pass

--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -1521,14 +1521,19 @@ class MetadataParser(object):
                         _val = twitter.get('content', None)
                         if _val is None:
                            _val = twitter.get('value', None)
-                    # clients expect an empty string though, not `None`
-                    _val = '' if _val is None else _val
                 else:
-                    _val = twitter.get('content', '')
+                    _val = twitter.get('content', None)
+
+                # clients expect a string, not none
+                # previous behavior was to exclude these items too
+                if _val is None:
+                    continue
+
                 parsed_result._add_discovered(_target_container='twitter',
                                               _target_key=_key,
                                               _raw_value=_val,
                                               )
+
             except (AttributeError, KeyError):
                 pass
 

--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -5,7 +5,7 @@ log = logging.getLogger(__name__)
 # ------------------------------------------------------------------------------
 
 
-__VERSION__ = '0.9.20-dev'
+__VERSION__ = '0.9.20'
 
 
 # ------------------------------------------------------------------------------
@@ -1029,6 +1029,7 @@ class MetadataParser(object):
     requests_session = None
     derive_encoding = None
     default_encoding = None
+    support_malformed = None
 
     # allow for the beautiful_soup to be saved
     soup = None
@@ -1042,7 +1043,7 @@ class MetadataParser(object):
         raise_on_invalid=False, search_head_only=None, allow_redirects=True,
         requests_session=None, only_parse_http_ok=True, defer_fetch=False,
         derive_encoding=True, html_encoding=None, default_encoding=None,
-        retry_dropped_without_headers=None,
+        retry_dropped_without_headers=None, support_malformed=None,
     ):
         """
         creates a new `MetadataParser` instance.
@@ -1127,6 +1128,9 @@ class MetadataParser(object):
             `retry_dropped_without_headers`
                 default: None
                 if True, will retry a dropped connection without headers
+            `support_malformed`
+                default: None
+                if True, will support parsing some commonly malformed tag implementations
         """
         if url is not None:
             url = url.strip()
@@ -1155,6 +1159,7 @@ class MetadataParser(object):
         self.requests_session = requests_session
         self.derive_encoding = derive_encoding
         self.default_encoding = default_encoding
+        self.support_malformed = support_malformed
         if only_parse_file_extensions is not None:
             self.only_parse_file_extensions = only_parse_file_extensions
         if html is None:
@@ -1166,7 +1171,7 @@ class MetadataParser(object):
                                               url_headers=url_headers,
                                               retry_dropped_without_headers=retry_dropped_without_headers,
                                               )
-                        self.parse(html)
+                        self.parse(html, support_malformed=support_malformed)
                         return
                     self.deferred_fetch = deferred_fetch
                     return
@@ -1184,7 +1189,7 @@ class MetadataParser(object):
                                           default_encoding=default_encoding,
                                           )
         if html:
-            self.parse(html)
+            self.parse(html, support_malformed=support_malformed)
 
     # --------------------------------------------------------------------------
 
@@ -1426,13 +1431,14 @@ class MetadataParser(object):
             allow_localhosts=self.allow_localhosts,
         )
 
-    def parse(self, html):
+    def parse(self, html, support_malformed=None):
         """
         parses submitted `html`
 
         args:
             html
         """
+        support_malformed = support_malformed if support_malformed is not None else self.support_malformed
         if not isinstance(html, BeautifulSoup):
             kwargs_bs = {}
             try:
@@ -1499,11 +1505,29 @@ class MetadataParser(object):
                                           )
         for twitter in twitters:
             try:
-                # for a twitter:label/data meta tags, we must use a 'value' attr
-                raw_value = twitter.get('content', twitter.get('value', None))
+                # for the deprecated "twitter:(label|data)" meta tags, we must use a 'value' attr
+                # other tags use the "content" attr
+                # some implementations uses "value" or "content" interchangeably though
+                _key = twitter['name'][8:]
+                if support_malformed or (_key.lower() in ('label', 'data')):
+                    _val = None  # scoping reminder
+                    if _key.lower() in ('label', 'data'):
+                        _val = twitter.get('value', None)
+                        if _val is None:
+                            if support_malformed:
+                                _val = twitter.get('content', None)
+                    elif support_malformed:
+                        # prefer `content` to `value`
+                        _val = twitter.get('content', None)
+                        if _val is None:
+                           _val = twitter.get('value', None)
+                    # clients expect an empty string though, not `None`
+                    _val = '' if _val is None else _val
+                else:
+                    _val = twitter.get('content', '')
                 parsed_result._add_discovered(_target_container='twitter',
-                                              _target_key=twitter['name'][8:],
-                                              _raw_value=raw_value,
+                                              _target_key=_key,
+                                              _raw_value=_val,
                                               )
             except (AttributeError, KeyError):
                 pass

--- a/tests/document_parsing.py
+++ b/tests/document_parsing.py
@@ -265,7 +265,7 @@ class TestDocumentParsing(unittest.TestCase):
         self.assertEqual(parsed.metadata['twitter']['title'], 'meta.name=twitter:title')
         self.assertEqual(parsed.metadata['twitter']['url'], 'https://example.com/meta/name=twitter:url')
         self.assertEqual(parsed.metadata['twitter']['data'], 'meta.name=twitter:data||value')
-        self.assertEqual(parsed.metadata['twitter']['label'], '')
+        self.assertNotIn('label', parsed.metadata['twitter'])
         self.assertEqual(parsed.is_opengraph_minimum(), True)
 
     def test_html_urls(self):
@@ -581,8 +581,8 @@ class TestDocumentParsing(unittest.TestCase):
         # in `simple.html`, "label" (incorrectly) uses "content" and "data" uses "label"
         parsed = metadata_parser.MetadataParser(url=None, html=html)
         self.assertEqual(parsed.metadata['twitter']['data'], 'meta.name=twitter:data||value')
-        self.assertEqual(parsed.metadata['twitter']['label'], '')
-        self.assertEqual(parsed.metadata['twitter']['invalid'], '')
+        self.assertNotIn('label', parsed.metadata['twitter'])
+        self.assertNotIn('invalid', parsed.metadata['twitter'])
 
         # now with `support_malformed` support we will load the label!
         parsed2 = metadata_parser.MetadataParser(url=None, html=html, support_malformed=True)
@@ -597,7 +597,7 @@ class TestDocumentParsing(unittest.TestCase):
         self.assertEqual(parsed_dupe.metadata['twitter']['data'], ['meta.name=twitter:data||value,1',
                                                                    'meta.name=twitter:data||value,2',
                                                                    ])
-        self.assertEqual(parsed_dupe.metadata['twitter']['label'], [''])
+        self.assertNotIn('label', parsed.metadata['twitter'])
 
         # everyone is happy when metadata is malformed!
         parsed_dupe = metadata_parser.MetadataParser(url=None, html=html_dupes, support_malformed=True)

--- a/tests/document_parsing.py
+++ b/tests/document_parsing.py
@@ -264,6 +264,8 @@ class TestDocumentParsing(unittest.TestCase):
         self.assertEqual(parsed.metadata['twitter']['site'], 'meta.name=twitter:site')
         self.assertEqual(parsed.metadata['twitter']['title'], 'meta.name=twitter:title')
         self.assertEqual(parsed.metadata['twitter']['url'], 'https://example.com/meta/name=twitter:url')
+        self.assertEqual(parsed.metadata['twitter']['data'], 'meta.name=twitter:data||value')
+        self.assertEqual(parsed.metadata['twitter']['label'], '')
         self.assertEqual(parsed.is_opengraph_minimum(), True)
 
     def test_html_urls(self):
@@ -299,7 +301,7 @@ class TestDocumentParsing(unittest.TestCase):
         """
         html = self._MakeOne('duplicates.html')
         parsed = metadata_parser.MetadataParser(url=None, html=html)
-        
+
         # this is just a property and should be the same object
         self.assertIs(parsed.metadata, parsed.parsed_result.metadata)
 
@@ -566,3 +568,45 @@ class TestDocumentParsing(unittest.TestCase):
         self.assertEqual(parsed.get_metadatas('TestMixedField3', strategy='all', encoder=encoder_capitalizer), {'meta': ['META:TESTMIXEDFIELD3', ],
                                                                                                                 'dc': [{'CONTENT': 'DC:TESTMIXEDFIELD3',},
                                                                                                                 ]})
+
+    def test_malformed_twitter(self):
+        """
+        this tests simple.html to have certain fields
+        python -munittest tests.document_parsing.TestDocumentParsing.test_malformed_twitter
+        """
+        html = self._MakeOne('simple.html')
+
+        # the default behavior is to not support malformed
+        # that means we should consult 'value' for data and 'label'
+        # in `simple.html`, "label" (incorrectly) uses "content" and "data" uses "label"
+        parsed = metadata_parser.MetadataParser(url=None, html=html)
+        self.assertEqual(parsed.metadata['twitter']['data'], 'meta.name=twitter:data||value')
+        self.assertEqual(parsed.metadata['twitter']['label'], '')
+        self.assertEqual(parsed.metadata['twitter']['invalid'], '')
+
+        # now with `support_malformed` support we will load the label!
+        parsed2 = metadata_parser.MetadataParser(url=None, html=html, support_malformed=True)
+        self.assertEqual(parsed2.metadata['twitter']['data'], 'meta.name=twitter:data||value')
+        self.assertEqual(parsed2.metadata['twitter']['label'], 'meta.name=twitter:label||content')
+        self.assertEqual(parsed2.metadata['twitter']['invalid'], 'meta.name=twitter:invalid')
+
+        # try it with dupes...
+        html_dupes = self._MakeOne('duplicates.html')
+        parsed_dupe = metadata_parser.MetadataParser(url=None, html=html_dupes)
+        # two items for each of data/label, but label is empty strings
+        self.assertEqual(parsed_dupe.metadata['twitter']['data'], ['meta.name=twitter:data||value,1',
+                                                                   'meta.name=twitter:data||value,2',
+                                                                   ])
+        self.assertEqual(parsed_dupe.metadata['twitter']['label'], [''])
+
+        # everyone is happy when metadata is malformed!
+        parsed_dupe = metadata_parser.MetadataParser(url=None, html=html_dupes, support_malformed=True)
+        self.assertEqual(parsed_dupe.metadata['twitter']['data'], ['meta.name=twitter:data||value,1',
+                                                                   'meta.name=twitter:data||value,2',
+                                                                   ])
+        self.assertEqual(parsed_dupe.metadata['twitter']['label'], ['meta.name=twitter:label||content,1',
+                                                                    'meta.name=twitter:label||content,2',
+                                                                    ])
+
+
+

--- a/tests/html_scaffolds/simple.html
+++ b/tests/html_scaffolds/simple.html
@@ -26,6 +26,10 @@
     <meta name='twitter:url' content='https://example.com/meta/name=twitter:url' />
     <meta name='twitter:description' content='meta.name=twitter:description' />
     <meta name='twitter:title' content='meta.name=twitter:title' />
+    <meta name='twitter:label' content='meta.name=twitter:label||content' />
+    <meta name='twitter:data' value='meta.name=twitter:data||value' />
+    <meta name='twitter:invalid' value='meta.name=twitter:invalid' />
+
 </head>
 <body>
 body


### PR DESCRIPTION
for issue https://github.com/jvanasco/metadata_parser/issues/14
rework of https://github.com/jvanasco/metadata_parser/pull/13

PR 13 was extended with tests, None was removed from being a potential parsed value, and a 'support_malformed' option was added.