### PR TITLE
Py3 str or bytes

### DIFF
--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -307,8 +307,14 @@ def derive_encoding__hook(resp, *args, **kwargs):
         # html5 spec requires a meta-charset in the first 1024 bytes
         _sample = resp.content[:1024]
         if PY3:
-            _sample = resp.content.decode()
-        resp._encoding_content = get_encodings_from_content(_sample)
+            _py3_sample = resp.content.decode()
+            try:
+                resp._encoding_content = get_encodings_from_content(_py3_sample)
+            except TypeError:
+                #sometimes _py3_sample seems to be str, when get_encodings_from_content expects bytes like, so catch, and fall through 
+                pass
+        if not resp._encoding_content:
+            resp._encoding_content = get_encodings_from_content(_sample)
     if resp._encoding_content:
         resp.encoding = resp._encoding_content[0]  # it's a list
     else:

--- a/metadata_parser/__init__.py
+++ b/metadata_parser/__init__.py
@@ -308,11 +308,9 @@ def derive_encoding__hook(resp, *args, **kwargs):
         _sample = resp.content[:1024]
         if PY3:
             _py3_sample = resp.content.decode()
-            try:
+            if isinstance(_py3_sample, bytes):
                 resp._encoding_content = get_encodings_from_content(_py3_sample)
-            except TypeError:
-                #sometimes _py3_sample seems to be str, when get_encodings_from_content expects bytes like, so catch, and fall through 
-                pass
+
         if not resp._encoding_content:
             resp._encoding_content = get_encodings_from_content(_sample)
     if resp._encoding_content:


### PR DESCRIPTION
I've found that some sites (https://www.primeenvirocleaners.com/ for example), return a `str` object from `_sample = resp.content.decode()`, rather than the `bytes`-like object that `get_encodings_from_content` expects. This just catches that error and falls back to `resp.content[1024]`.

Not sure if this is the best way to fix this issue, there might be a more elegant way.