### PR TITLE
Fix issue 17

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,6 +1,31 @@
 1.0
     1.0 will be a complete api overhaul
 
+TODO:
+	* cache the parsed urls
+
+0.9.21
+	* addressing issue #17 (https://github.com/jvanasco/metadata_parser/issues/17) where `get_link_` logic does not handle schemeless urls.
+	** `MetadataParser.get_metadata_link` will now try to upgrade schemeless links (e.g. urls that start with "//")
+	** `MetadataParser.get_metadata_link` will now check values against `FIELDS_REQUIRE_HTTPS` in certain situations to see if the value is valid for http
+	** `MetadataParser.schemeless_fields_upgradeable` is a tuple of the fields which can be upgradeable. this defaults to a package definition, but can be changed on a per-parser bases.
+		The defaults are:
+			'image',
+			'og:image', 'og:image:url', 'og:audio', 'og:video', 
+			'og:image:secure_url', 'og:audio:secure_url', 'og:video:secure_url',		
+	** `MetadataParser.schemeless_fields_disallow` is a tuple of the fields which can not be upgradeable. this defaults to a package definition, but can be changed on a per-parser bases.
+		The defaults are:
+			'canonical',
+			'og:url',
+	** `MetadataParser.get_url_scheme()` is a new method to expose the scheme of the active url
+	** `MetadataParser.upgrade_schemeless_url()` is a new method to upgrade schemeless links
+		it accepts two arguments: url and field(optional)
+		if present, the field is checked against the package tuple FIELDS_REQUIRE_HTTPS to see if the value is valid for http
+			'og:image:secure_url',
+			'og:audio:secure_url',
+			'og:video:secure_url',
+
+
 0.9.20
 	* support for deprecated `twitter:label` and `twitter:data` metatags, which use "value" instead of "content".
 	* new param to `__init__` and `parse`: `support_malformed` (default `None`).

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2017, Jonathan Vanasco <jonathan@findmeon.com>
+Copyright (c) 2012-2018, Jonathan Vanasco <jonathan@findmeon.com>
 
 MIT License -- http://www.opensource.org/licenses/mit-license
 

--- a/README.rst
+++ b/README.rst
@@ -212,7 +212,7 @@ Tests were added to handle dublincore data. An extra attribute may be needed to 
 Usage
 ==============
 
-Until version 0.9.19, the recommended way to get metadata was to use `get_metadata` which will return a string (or None):
+Until version `0.9.19`, the recommended way to get metadata was to use `get_metadata` which will return a string (or None):
 
 **From an URL**
 
@@ -231,6 +231,21 @@ Until version 0.9.19, the recommended way to get metadata was to use `get_metada
     >>> print page.get_metadatas('title')
     >>> print page.get_metadatas('title', strategy=['og',])
     >>> print page.get_metadatas('title', strategy=['page', 'og', 'dc',])
+
+
+Malformed Data
+======================
+
+It is very common to find malformed data. As of version `0.9.20` the following methods should be used to allow malformed presentation:
+
+    >>> page = metadata_parser.MetadataParser(html=HTML, support_malformed=True)
+
+or
+
+    >>> parsed = page.parse(html=html, support_malformed=True)
+	>>> parsed = page.parse(html=html, support_malformed=False)
+
+The above options will support parsing common malformed options.  Currently this only looks at alternate (improper) ways of producing twitter tags, but may be expanded
 
 
 Notes

--- a/tests/document_parsing.py
+++ b/tests/document_parsing.py
@@ -40,6 +40,28 @@ docs = {
             'get_discrete_url()': 'http://example.com/og.html',
         },
     },
+    'good-canonical-absolute-noschema': {
+        'url-real': """http://example.com""",
+        'head': {
+            'url-canonical': """//example.com/canonical.html""",
+            'url-og': None,
+        },
+        'expected': {
+            'get_discrete_url()': 'http://example.com/canonical.html',
+        },
+    },
+    'good-og-absolute-noschema': {
+        'url-real': """http://example.com""",
+        'head': {
+            'url-canonical': None,
+            'url-og': """//example.com/og.html""",
+        },
+        'expected': {
+            'get_discrete_url()': 'http://example.com/og.html',
+        },
+    },
+
+
     'good-canonical-relative': {
         'url-real': """http://example.com""",
         'head': {
@@ -159,13 +181,19 @@ class TestHtmlDocument(unittest.TestCase):
     def test_get_discrete_url__good_relative(self):
         errors = _docs_test(['good-canonical-relative',
                              'good-canonical-relative_alt',
-                             'good-og-relative_alt', ]
+                             'good-og-relative_alt', 
+                             ]
                             )
         if errors:
             raise ValueError(errors)
 
     def test_get_discrete_url__good_absolute(self):
         errors = _docs_test(['good-canonical-absolute', 'good-og-absolute', ])
+        if errors:
+            raise ValueError(errors)
+
+    def test_get_discrete_url__good_absolute(self):
+        errors = _docs_test(['good-canonical-absolute-noschema', 'good-og-absolute-noschema', ])
         if errors:
             raise ValueError(errors)
 


### PR DESCRIPTION
fixes for issue #17 

	* addressing issue #17 (https://github.com/jvanasco/metadata_parser/issues/17) where `get_link_` logic does not handle schemeless urls.
	** `MetadataParser.get_metadata_link` will now try to upgrade schemeless links (e.g. urls that start with "//")
	** `MetadataParser.get_metadata_link` will now check values against `FIELDS_REQUIRE_HTTPS` in certain situations to see if the value is valid for http
	** `MetadataParser.schemeless_fields_upgradeable` is a tuple of the fields which can be upgradeable. this defaults to a package definition, but can be changed on a per-parser bases.
		The defaults are:
			'image',
			'og:image', 'og:image:url', 'og:audio', 'og:video', 
			'og:image:secure_url', 'og:audio:secure_url', 'og:video:secure_url',		
	** `MetadataParser.schemeless_fields_disallow` is a tuple of the fields which can not be upgradeable. this defaults to a package definition, but can be changed on a per-parser bases.
		The defaults are:
			'canonical',
			'og:url',
	** `MetadataParser.get_url_scheme()` is a new method to expose the scheme of the active url
	** `MetadataParser.upgrade_schemeless_url()` is a new method to upgrade schemeless links
		it accepts two arguments: url and field(optional)
		if present, the field is checked against the package tuple FIELDS_REQUIRE_HTTPS to see if the value is valid for http
			'og:image:secure_url',
			'og:audio:secure_url',
			'og:video:secure_url',