### PR TITLE
change log level to debug for MetadataParser.fetch_url(%s)

### DIFF
--- a/src/metadata_parser/__init__.py
+++ b/src/metadata_parser/__init__.py
@@ -1742,7 +1742,7 @@ class MetadataParser(object):
                 if true, will retry_dropped_without_headers
         """
         if __debug__:
-            log.error("MetadataParser.fetch_url(%s)", self.url)
+            log.debug("MetadataParser.fetch_url(%s)", self.url)
         # should we even download/parse this?
         force_parse = force_parse if force_parse is not None else self.force_parse
         force_parse_invalid_content_type = (


### PR DESCRIPTION
This information is meant for debug purposes and it's not an error