### PR TITLE
Remove cgi dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,9 +34,6 @@ requires = [
 if sys.version_info.major == 2:
     requires.append("backports.html")
 
-if sys.version_info >= (3, 13):
-    requires.append("legacy-cgi")
-
 tests_require = [
     "httpbin",
     "pytest",

--- a/src/metadata_parser/__init__.py
+++ b/src/metadata_parser/__init__.py
@@ -1,7 +1,6 @@
 import _socket  # noqa: I100,I201  # peername hack, see below
 
 # stdlib
-import cgi  # noqa: I100,I201
 import collections
 import datetime
 from html import unescape as html_unescape
@@ -46,7 +45,7 @@ FUTURE_BEHAVIOR = bool(int(os.getenv("METADATA_PARSER_FUTURE", "0")))
 # ==============================================================================
 
 
-__VERSION__ = "0.12.2"
+__VERSION__ = "0.12.3"
 
 
 # ------------------------------------------------------------------------------
@@ -313,11 +312,12 @@ def get_encoding_from_headers(headers: CaseInsensitiveDict) -> Optional[str]:
     content_type = headers.get("content-type")
     if not content_type:
         return None
-    content_type, params = cgi.parse_header(content_type)
-    if "charset" in params:
-        return params["charset"].strip("'\"")
+    if not "charset" in content_type:
+        return None
+    for param in content_type.replace(" ", "").split(";"):
+        if "charset=" in param:
+            return param.split("=")[-1]
     return None
-
 
 # ------------------------------------------------------------------------------
 

--- a/src/metadata_parser/__init__.py
+++ b/src/metadata_parser/__init__.py
@@ -319,6 +319,7 @@ def get_encoding_from_headers(headers: CaseInsensitiveDict) -> Optional[str]:
             return param.split("=")[-1]
     return None
 
+
 # ------------------------------------------------------------------------------
 
 
@@ -1948,8 +1949,7 @@ class MetadataParser(object):
                     )
                 log.error("NotParsable | %s", self.url)
                 raise NotParsable(
-                    "NotParseable document detected! "
-                    "content-type:'[%s]" % content_type,
+                    "NotParseable document detected! content-type:'[%s]" % content_type,
                     metadataParser=self,
                 )
 


### PR DESCRIPTION
Actually Python 3.13 isn't supported because cgi module is missing. in PR #44 (issue #43 ) I fix it by adding package `legacy-cgi`  

In this PR I entirely remove cgi package by rewriting function. All tests pass :) 

The second commit I just running a linter on the modified file. 